### PR TITLE
biometrics: Allow posting reset runnable for all clients

### DIFF
--- a/core/res/res/values/ssos_config.xml
+++ b/core/res/res/values/ssos_config.xml
@@ -23,6 +23,10 @@
     <!-- Whether to cleanup fingerprints upon connection to the daemon and when user switches -->
     <bool name="config_cleanupUnusedFingerprints">true</bool>
 
+    <!-- Whether to post reset runnable for all clients. Needed for some older
+         vendor fingerprint HAL implementations. -->
+    <bool name="config_fingerprintPostResetRunnableForAllClients">false</bool>
+
     <!-- Paths to the libraries that contain device specific key handlers -->
     <string-array name="config_deviceKeyHandlerLibs" translatable="false">
     </string-array>

--- a/core/res/res/values/ssos_symbols.xml
+++ b/core/res/res/values/ssos_symbols.xml
@@ -25,6 +25,9 @@
      <!-- Whether to cleanup fingerprints upon connection to the daemon and when user switches -->
      <java-symbol type="bool" name="config_cleanupUnusedFingerprints" />
 
+     <!-- Post reset runnable for all clients -->
+     <java-symbol type="bool" name="config_fingerprintPostResetRunnableForAllClients" />
+
      <!-- Device keyhandlers -->
      <java-symbol type="array" name="config_deviceKeyHandlerLibs" />
      <java-symbol type="array" name="config_deviceKeyHandlerClasses" />

--- a/services/core/java/com/android/server/biometrics/BiometricServiceBase.java
+++ b/services/core/java/com/android/server/biometrics/BiometricServiceBase.java
@@ -92,6 +92,7 @@ public abstract class BiometricServiceBase extends SystemService
     private final ResetClientStateRunnable mResetClientState = new ResetClientStateRunnable();
     private final ArrayList<LockoutResetMonitor> mLockoutMonitors = new ArrayList<>();
     private final boolean mCleanupUnusedFingerprints;
+    private final boolean mPostResetRunnableForAllClients;
 
     protected final IStatusBarService mStatusBarService;
     protected final Map<Integer, Long> mAuthenticatorIds =
@@ -664,6 +665,8 @@ public abstract class BiometricServiceBase extends SystemService
         mMetricsLogger = new MetricsLogger();
         mCleanupUnusedFingerprints = mContext.getResources().getBoolean(
                 com.android.internal.R.bool.config_cleanupUnusedFingerprints);
+        mPostResetRunnableForAllClients = mContext.getResources().getBoolean(
+                com.android.internal.R.bool.config_fingerprintPostResetRunnableForAllClients);
     }
 
     @Override
@@ -1074,6 +1077,10 @@ public abstract class BiometricServiceBase extends SystemService
                             + newClient.getClass().getSuperclass().getSimpleName()
                             + "(" + newClient.getOwnerString() + ")"
                             + ", initiatedByClient = " + initiatedByClient);
+                }
+                if (mPostResetRunnableForAllClients) {
+                    mHandler.removeCallbacks(mResetClientState);
+                    mHandler.postDelayed(mResetClientState, CANCEL_TIMEOUT_LIMIT);
                 }
             } else {
                 currentClient.stop(initiatedByClient);


### PR DESCRIPTION
 * After commit df755c8, some devices fail to enumerate for
   unknown reason (likely a HAL issue). Add an overlay to
   restore old behavior and thus workaround this issue.

Change-Id: Ib0d00d5987aa7f68a5c7efa785859e8eb208651d