### PR TITLE
Revert "EventLog: Disable event writing in production builds"

### DIFF
--- a/core/java/android/util/EventLog.java
+++ b/core/java/android/util/EventLog.java
@@ -20,7 +20,6 @@ import android.annotation.NonNull;
 import android.annotation.Nullable;
 import android.annotation.SystemApi;
 import android.compat.annotation.UnsupportedAppUsage;
-import android.os.Build;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -328,19 +327,7 @@ public class EventLog {
         }
     }
 
-    /**
-     * Record an event log message.
-     * @param tag The event type tag code
-     * @param value A value to log
-     * @return The number of bytes written
-     */
-    public static int writeEvent(int tag, int value) {
-        if (!Build.IS_ENG) {
-            return 0;
-        }
-
-        return nativeWriteEvent(tag, value);
-    }
+    // We assume that the native methods deal with any concurrency issues.
 
     /**
      * Record an event log message.
@@ -348,13 +335,7 @@ public class EventLog {
      * @param value A value to log
      * @return The number of bytes written
      */
-    public static int writeEvent(int tag, long value) {
-        if (!Build.IS_ENG) {
-            return 0;
-        }
-
-        return nativeWriteEvent(tag, value);
-    }
+    public static native int writeEvent(int tag, int value);
 
     /**
      * Record an event log message.
@@ -362,13 +343,15 @@ public class EventLog {
      * @param value A value to log
      * @return The number of bytes written
      */
-    public static int writeEvent(int tag, float value) {
-        if (!Build.IS_ENG) {
-            return 0;
-        }
+    public static native int writeEvent(int tag, long value);
 
-        return nativeWriteEvent(tag, value);
-    }
+    /**
+     * Record an event log message.
+     * @param tag The event type tag code
+     * @param value A value to log
+     * @return The number of bytes written
+     */
+    public static native int writeEvent(int tag, float value);
 
     /**
      * Record an event log message.
@@ -376,13 +359,7 @@ public class EventLog {
      * @param str A value to log
      * @return The number of bytes written
      */
-    public static int writeEvent(int tag, String str) {
-        if (!Build.IS_ENG) {
-            return 0;
-        }
-
-        return nativeWriteEvent(tag, str);
-    }
+    public static native int writeEvent(int tag, String str);
 
     /**
      * Record an event log message.
@@ -390,13 +367,7 @@ public class EventLog {
      * @param list A list of values to log
      * @return The number of bytes written
      */
-    public static int writeEvent(int tag, Object... list) {
-        if (!Build.IS_ENG) {
-            return 0;
-        }
-
-        return nativeWriteEvent(tag, list);
-    }
+    public static native int writeEvent(int tag, Object... list);
 
     /**
      * Read events from the log, filtered by type.
@@ -404,14 +375,8 @@ public class EventLog {
      * @param output container to add events into
      * @throws IOException if something goes wrong reading events
      */
-    public static void readEvents(int[] tags, Collection<Event> output)
-            throws IOException {
-        if (!Build.IS_ENG) {
-            return;
-        }
-
-        nativeReadEvents(tags, output);
-    }
+    public static native void readEvents(int[] tags, Collection<Event> output)
+            throws IOException;
 
     /**
      * Read events from the log, filtered by type, blocking until logs are about to be overwritten.
@@ -422,27 +387,7 @@ public class EventLog {
      * @hide
      */
     @SystemApi
-    public static void readEventsOnWrapping(int[] tags, long timestamp,
-            Collection<Event> output)
-            throws IOException {
-        if (!Build.IS_ENG) {
-            return;
-        }
-
-        nativeReadEventsOnWrapping(tags, timestamp, output);
-    }
-
-    // We assume that the native methods deal with any concurrency issues.
-
-    private static native int nativeWriteEvent(int tag, int value);
-    private static native int nativeWriteEvent(int tag, long value);
-    private static native int nativeWriteEvent(int tag, float value);
-    private static native int nativeWriteEvent(int tag, String str);
-    private static native int nativeWriteEvent(int tag, Object... list);
-
-    private static native void nativeReadEvents(int[] tags, Collection<Event> output)
-            throws IOException;
-    private static native void nativeReadEventsOnWrapping(int[] tags, long timestamp,
+    public static native void readEventsOnWrapping(int[] tags, long timestamp,
             Collection<Event> output)
             throws IOException;
 

--- a/core/jni/android_util_EventLog.cpp
+++ b/core/jni/android_util_EventLog.cpp
@@ -69,16 +69,16 @@ static void android_util_EventLog_readEventsOnWrapping(JNIEnv* env, jobject claz
  */
 static const JNINativeMethod gRegisterMethods[] = {
     /* name, signature, funcPtr */
-    { "nativeWriteEvent", "(II)I", (void*) ELog::writeEventInteger },
-    { "nativeWriteEvent", "(IJ)I", (void*) ELog::writeEventLong },
-    { "nativeWriteEvent", "(IF)I", (void*) ELog::writeEventFloat },
-    { "nativeWriteEvent", "(ILjava/lang/String;)I", (void*) ELog::writeEventString },
-    { "nativeWriteEvent", "(I[Ljava/lang/Object;)I", (void*) ELog::writeEventArray },
-    { "nativeReadEvents",
+    { "writeEvent", "(II)I", (void*) ELog::writeEventInteger },
+    { "writeEvent", "(IJ)I", (void*) ELog::writeEventLong },
+    { "writeEvent", "(IF)I", (void*) ELog::writeEventFloat },
+    { "writeEvent", "(ILjava/lang/String;)I", (void*) ELog::writeEventString },
+    { "writeEvent", "(I[Ljava/lang/Object;)I", (void*) ELog::writeEventArray },
+    { "readEvents",
       "([ILjava/util/Collection;)V",
       (void*) android_util_EventLog_readEvents
     },
-    { "nativeReadEventsOnWrapping",
+    { "readEventsOnWrapping",
       "([IJLjava/util/Collection;)V",
       (void*) android_util_EventLog_readEventsOnWrapping
     },


### PR DESCRIPTION
 * This commit is incorrect because of two reasons. First, public API
   should not be modified in any case. Second, there are actually apps
   using event log feature to perform black magic. For example, Brevent
   (https://play.google.com/store/apps/details?id=me.piebridge.brevent)
   checks event log to determine when apps are moved into background
   and kill them after some time accordingly.

This reverts commit 1fbf73590c8024b1d7b4b51675fa2e9f1b1479d4