### PR TITLE
SystemUI: Display wifi data usage in QS footer when connected

### DIFF
--- a/packages/SystemUI/res/values/ssos_strings.xml
+++ b/packages/SystemUI/res/values/ssos_strings.xml
@@ -38,6 +38,7 @@
     <string name="qs_data_switch_changed_2">Using SIM 2 for Mobile data</string>
     <string name="qs_data_switch_toast_0">Currently no SIM card is inserted</string>
     <string name="qs_data_switch_toast_1">Currently only one SIM card is inserted</string>
+    <string name="usage_wifi_prefix">Wi-Fi</string>
 
     <!-- Caffeine QS Tile -->
     <string name="quick_settings_caffeine_label">Caffeine</string>


### PR DESCRIPTION
* Also prefix wifi or data before usage text
* Manages logic to maintain "handle no SIM card state" & Wifi data usage in QS

Signed-off-by: Mr. EndLess <aryanmk.mk5@gmail.com>