### PR TITLE
Revert "NotificationShade should animate away on MODE_UNLOCK_COLLAPSING"

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/BiometricUnlockController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/BiometricUnlockController.java
@@ -116,7 +116,7 @@ public class BiometricUnlockController extends KeyguardUpdateMonitorCallback imp
 
     /**
      * Mode in which fingerprint unlocks the device or passive auth (ie face auth) unlocks the
-     * device while being requested when keyguard is occluded or showing.
+     * device while being requested when keyguard is occluded.
      */
     public static final int MODE_UNLOCK_COLLAPSING = 5;
 
@@ -425,11 +425,6 @@ public class BiometricUnlockController extends KeyguardUpdateMonitorCallback imp
                 if (!wasDeviceInteractive) {
                     mPendingShowBouncer = true;
                 } else {
-                    mShadeController.animateCollapsePanels(
-                            CommandQueue.FLAG_EXCLUDE_NONE,
-                            true /* force */,
-                            false /* delayed */,
-                            BIOMETRIC_COLLAPSE_SPEEDUP_FACTOR);
                     mPendingShowBouncer = false;
                     mKeyguardViewController.notifyKeyguardAuthenticated(
                             false /* strongAuth */);

--- a/packages/SystemUI/tests/src/com/android/systemui/statusbar/phone/BiometricsUnlockControllerTest.java
+++ b/packages/SystemUI/tests/src/com/android/systemui/statusbar/phone/BiometricsUnlockControllerTest.java
@@ -274,26 +274,6 @@ public class BiometricsUnlockControllerTest extends SysuiTestCase {
     }
 
     @Test
-    public void onBiometricAuthenticated_onLockScreen() {
-        // GIVEN not dozing
-        when(mUpdateMonitor.isDeviceInteractive()).thenReturn(true);
-
-        // WHEN we want to unlock collapse
-        mBiometricUnlockController.startWakeAndUnlock(
-                BiometricUnlockController.MODE_UNLOCK_COLLAPSING);
-
-        // THEN we collpase the panels and notify authenticated
-        verify(mShadeController).animateCollapsePanels(
-                /* flags */ anyInt(),
-                /* force */ eq(true),
-                /* delayed */ eq(false),
-                /* speedUpFactor */ anyFloat()
-        );
-        verify(mStatusBarKeyguardViewManager).notifyKeyguardAuthenticated(
-                /* strongAuth */ eq(false));
-    }
-
-    @Test
     public void onBiometricAuthenticated_whenFace_noBypass_encrypted_doNothing() {
         reset(mUpdateMonitor);
         mBiometricUnlockController.setKeyguardViewController(mStatusBarKeyguardViewManager);


### PR DESCRIPTION
This fixes an issue where notification drawer becomes transparent.

Test:
Swipe down QS panel, adjust brightness bar and Swipe up again;
Notification drawer stays opaque as it should with the revert.

This reverts commit e000435d7fcafff54647ee6ddb1ee0387c7ebaaf.

Change-Id: Id946a7674301f6d1240bb2a1a066f5c789183021
Signed-off-by: kubersharma001 <kubersharma001@gmail.com>